### PR TITLE
Apply commit suggestions in Browse view with “s” and “S” keys

### DIFF
--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/gh-tui-tools/gh-review-conductor/pkg/applier"
 	"github.com/gh-tui-tools/gh-review-conductor/pkg/github"
 	"github.com/gh-tui-tools/gh-review-conductor/pkg/ui"
 	"github.com/spf13/cobra"
@@ -326,6 +327,59 @@ func runBrowse(cmd *cobra.Command, args []string) error {
 			return fmt.Sprintf("%s %s.", displayEmoji, link), nil
 		}
 
+		// Apply suggestion actions
+		app := applier.New()
+		app.SetDebug(browseDebug)
+		app.SetGitHubClient(client)
+		renderer.applier = app
+
+		checkSuggestionPreconditions := func(item BrowseItem) error {
+			if item.Type == "file" {
+				return fmt.Errorf("cannot apply to file header")
+			}
+			if !item.Comment.HasSuggestion {
+				return fmt.Errorf("no suggestion to apply")
+			}
+			return nil
+		}
+
+		applyAndGetMessage := func(item BrowseItem) (string, error) {
+			if err := checkSuggestionPreconditions(item); err != nil {
+				return "", err
+			}
+			if err := app.ApplySuggestion(item.Comment); err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("Applied suggestion to %s:%d", item.Comment.Path, item.Comment.Line), nil
+		}
+
+		applySuggestionPreview := func(item BrowseItem) (string, error) {
+			if err := checkSuggestionPreconditions(item); err != nil {
+				return "", err
+			}
+			return app.PreviewSuggestion(item.Comment)
+		}
+
+		applySuggestionAction := func(item BrowseItem) (string, error) {
+			return applyAndGetMessage(item)
+		}
+
+		applySuggestionResolveAction := func(item BrowseItem) (string, error) {
+			msg, err := applyAndGetMessage(item)
+			if err != nil {
+				return "", err
+			}
+			// Resolve the thread if possible
+			if item.Comment.ThreadID != "" && !item.Comment.IsResolved() {
+				if err := client.ResolveThread(item.Comment.ThreadID); err != nil {
+					return msg + " (failed to resolve thread)", nil
+				}
+				item.Comment.SubjectType = "resolved"
+				msg += " and resolved thread"
+			}
+			return msg, nil
+		}
+
 		selected, err := ui.Select(ui.SelectorOptions[BrowseItem]{
 			Items:    browseItems,
 			Renderer: renderer,
@@ -371,6 +425,15 @@ func runBrowse(cmd *cobra.Command, args []string) error {
 			ReactionAction:   reactionAction,
 			ReactionComplete: reactionComplete,
 			ReactionKey:      "x react",
+
+			// s key: apply suggestion
+			ApplySuggestionPreview: applySuggestionPreview,
+			ApplySuggestionAction:  applySuggestionAction,
+			ApplySuggestionKey:     "s apply",
+
+			// S key: apply suggestion and resolve
+			ApplySuggestionResolveAction: applySuggestionResolveAction,
+			ApplySuggestionResolveKey:    "S apply+resolve",
 		})
 		if err != nil {
 			if errors.Is(err, ui.ErrNoSelection) {
@@ -549,6 +612,7 @@ type browseItemRenderer struct {
 	repo           string
 	prNumber       int
 	collapsedFiles map[string]bool
+	applier        *applier.Applier
 }
 
 func (r *browseItemRenderer) Title(item BrowseItem) string {
@@ -679,25 +743,36 @@ func (r *browseItemRenderer) PreviewWithHighlight(item BrowseItem, highlightIdx 
 		}
 	}
 
-	// Suggested code (with syntax highlighting based on file type)
+	// Suggestion diff (show actual diff if applier is available and file exists locally)
 	if comment.HasSuggestion && comment.SuggestedCode != "" {
-		preview.WriteString(ui.Colorize(ui.ColorCyan, "\n--- Suggested Code ---\n"))
-		lang := ui.CodeFenceLanguageFromPath(comment.Path)
-		md := fmt.Sprintf("```%s\n%s\n```", lang, comment.SuggestedCode)
-		if rendered, err := ui.RenderMarkdown(md); err == nil && rendered != "" {
-			preview.WriteString(rendered)
-		} else {
-			preview.WriteString(ui.Colorize(ui.ColorGreen, comment.SuggestedCode))
+		var showedDiff bool
+		if r.applier != nil {
+			if diffStr, err := r.applier.PreviewSuggestion(comment); err == nil {
+				preview.WriteString(ui.Colorize(ui.ColorCyan, "\n--- Suggestion Diff ---\n"))
+				preview.WriteString(ui.ColorizeDiff(diffStr))
+				preview.WriteString("\n")
+				showedDiff = true
+			}
 		}
-		preview.WriteString("\n")
+		if !showedDiff {
+			preview.WriteString(ui.Colorize(ui.ColorCyan, "\n--- Suggested Code ---\n"))
+			lang := ui.CodeFenceLanguageFromPath(comment.Path)
+			md := fmt.Sprintf("```%s\n%s\n```", lang, comment.SuggestedCode)
+			if rendered, err := ui.RenderMarkdown(md); err == nil && rendered != "" {
+				preview.WriteString(rendered)
+			} else {
+				preview.WriteString(ui.Colorize(ui.ColorGreen, comment.SuggestedCode))
+			}
+			preview.WriteString("\n")
+		}
 	}
 
-	// Diff hunk/context (with coloring, limited to 8 lines for relevance)
+	// Diff hunk/context (show the last lines closest to the comment)
 	if comment.DiffHunk != "" {
 		diffLines := strings.Split(comment.DiffHunk, "\n")
 		if len(diffLines) > 2 {
 			preview.WriteString(ui.Colorize(ui.ColorCyan, "\n--- Context ---\n"))
-			truncated := ui.TruncateDiff(comment.DiffHunk, 8)
+			truncated := ui.TruncateDiffTail(comment.DiffHunk, 8)
 			preview.WriteString(ui.ColorizeDiff(truncated))
 			preview.WriteString("\n")
 		}

--- a/cmd/browse_test.go
+++ b/cmd/browse_test.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
 
+	"github.com/gh-tui-tools/gh-review-conductor/pkg/applier"
 	"github.com/gh-tui-tools/gh-review-conductor/pkg/github"
 	"github.com/gh-tui-tools/gh-review-conductor/pkg/ui"
 )
@@ -358,5 +361,181 @@ func TestStripMarkdownForPreview(t *testing.T) {
 				t.Errorf("stripMarkdownForPreview(%q) = %q, want %q", tt.input, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestPreviewWithHighlight_SuggestionDiff(t *testing.T) {
+	// Create a temp file so PreviewSuggestion can read it
+	dir := t.TempDir()
+	// Resolve symlinks so paths match os.Getwd() on macOS (/var -> /private/var)
+	dir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	filePath := filepath.Join(dir, "test.go")
+	fileContent := "package main\n\nfunc hello() {\n\tfmt.Println(\"hello\")\n}\n"
+	if err := os.WriteFile(filePath, []byte(fileContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// chdir so validatePath accepts the file path
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	app := applier.New()
+
+	renderer := &browseItemRenderer{
+		repo:           "owner/repo",
+		prNumber:       123,
+		collapsedFiles: make(map[string]bool),
+		applier:        app,
+	}
+
+	item := BrowseItem{
+		Type: "comment",
+		Path: filePath,
+		Comment: &github.ReviewComment{
+			ID:            1,
+			Author:        "reviewer",
+			Body:          "Use Println from log package",
+			Path:          filePath,
+			Line:          4,
+			StartLine:     0,
+			HasSuggestion: true,
+			SuggestedCode: "\tlog.Println(\"hello\")\n",
+		},
+	}
+
+	preview := renderer.PreviewWithHighlight(item, -1)
+
+	// Should show "Suggestion Diff" header (not "Suggested Code")
+	if !strings.Contains(preview, "Suggestion Diff") {
+		t.Errorf("preview should contain \"Suggestion Diff\" header, got:\n%s", preview)
+	}
+
+	// Should contain actual diff markers
+	if !strings.Contains(preview, "-\tfmt.Println") {
+		t.Errorf("preview should show removed line with -, got:\n%s", preview)
+	}
+	if !strings.Contains(preview, "+\tlog.Println") {
+		t.Errorf("preview should show added line with +, got:\n%s", preview)
+	}
+}
+
+func TestPreviewWithHighlight_SuggestionDiffFallback(t *testing.T) {
+	// When file doesn\'t exist, should fall back to "Suggested Code"
+	renderer := &browseItemRenderer{
+		repo:           "owner/repo",
+		prNumber:       123,
+		collapsedFiles: make(map[string]bool),
+		applier:        applier.New(),
+	}
+
+	item := BrowseItem{
+		Type: "comment",
+		Path: "/nonexistent/file.go",
+		Comment: &github.ReviewComment{
+			ID:            1,
+			Author:        "reviewer",
+			Body:          "Fix this",
+			Path:          "/nonexistent/file.go",
+			Line:          1,
+			StartLine:     0,
+			HasSuggestion: true,
+			SuggestedCode: "replacement code\n",
+		},
+	}
+
+	preview := renderer.PreviewWithHighlight(item, -1)
+
+	// Should fall back to "Suggested Code" header
+	if !strings.Contains(preview, "Suggested Code") {
+		t.Errorf("preview should fall back to \"Suggested Code\" when file missing, got:\n%s", preview)
+	}
+}
+
+func TestPreviewWithHighlight_NoApplier(t *testing.T) {
+	// When no applier is set, should show "Suggested Code"
+	renderer := &browseItemRenderer{
+		repo:           "owner/repo",
+		prNumber:       123,
+		collapsedFiles: make(map[string]bool),
+		applier:        nil,
+	}
+
+	item := BrowseItem{
+		Type: "comment",
+		Path: "test.go",
+		Comment: &github.ReviewComment{
+			ID:            1,
+			Author:        "reviewer",
+			Body:          "Fix this",
+			Path:          "test.go",
+			Line:          1,
+			StartLine:     0,
+			HasSuggestion: true,
+			SuggestedCode: "replacement\n",
+		},
+	}
+
+	preview := renderer.PreviewWithHighlight(item, -1)
+
+	if !strings.Contains(preview, "Suggested Code") {
+		t.Errorf("preview should show \"Suggested Code\" without applier, got:\n%s", preview)
+	}
+}
+
+func TestPreviewWithHighlight_ContextShowsTail(t *testing.T) {
+	renderer := &browseItemRenderer{
+		repo:           "owner/repo",
+		prNumber:       123,
+		collapsedFiles: make(map[string]bool),
+	}
+
+	// Create a long diff hunk (like a new file) where the context near
+	// the comment is at the end
+	var hunkLines []string
+	hunkLines = append(hunkLines, "@@ -0,0 +1,20 @@")
+	for i := 1; i <= 20; i++ {
+		hunkLines = append(hunkLines, "+line "+strings.Repeat("x", i))
+	}
+	longHunk := strings.Join(hunkLines, "\n")
+
+	item := BrowseItem{
+		Type: "comment",
+		Path: "newfile.go",
+		Comment: &github.ReviewComment{
+			ID:       1,
+			Author:   "reviewer",
+			Body:     "Comment near end of file",
+			Path:     "newfile.go",
+			Line:     20,
+			DiffHunk: longHunk,
+		},
+	}
+
+	preview := renderer.PreviewWithHighlight(item, -1)
+
+	// Should contain "Context" header
+	if !strings.Contains(preview, "Context") {
+		t.Errorf("preview should contain Context section, got:\n%s", preview)
+	}
+
+	// Should show lines near the end (tail), not the beginning
+	// The last line is "+line xxxxxxxxxxxxxxxxxxxx" (20 x's)
+	if !strings.Contains(preview, strings.Repeat("x", 20)) {
+		t.Errorf("preview context should show tail lines (near comment), got:\n%s", preview)
+	}
+
+	// Should NOT show the very first content line (line 1 with 1 x)
+	// unless the hunk is short enough to show entirely
+	if strings.Contains(preview, "+line x\n") {
+		t.Errorf("preview context should not show lines from start of long hunk, got:\n%s", preview)
 	}
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -119,7 +119,8 @@ func runList(cmd *cobra.Command, args []string) error {
 func filterByThreadID(comments []*github.ReviewComment, threadID string) []*github.ReviewComment {
 	filtered := comments[:0]
 	for _, comment := range comments {
-		if comment.ThreadID == threadID {
+		// Match by GraphQL thread ID or by comment database ID
+		if comment.ThreadID == threadID || fmt.Sprintf("%d", comment.ID) == threadID {
 			filtered = append(filtered, comment)
 		}
 	}

--- a/pkg/applier/applier.go
+++ b/pkg/applier/applier.go
@@ -45,11 +45,124 @@ func (a *Applier) SetGitHubClient(client *github.Client) {
 	a.githubClient = client
 }
 
+// ApplySuggestion applies a suggestion using the comment's StartLine/Line fields directly.
+// This is used by the Browse view where the suggestion targets are known line ranges.
+// The "apply" subcommand uses applySuggestion instead, which parses the diff hunk.
+func (a *Applier) ApplySuggestion(comment *github.ReviewComment) error {
+	if err := validatePath(comment.Path); err != nil {
+		return err
+	}
+
+	fileContent, err := os.ReadFile(comment.Path)
+	if err != nil {
+		return fmt.Errorf("failed to read file %s: %w", comment.Path, err)
+	}
+	fileLines := strings.Split(string(fileContent), "\n")
+
+	targetLine, removeCount, err := a.findReplacementTargetByLineRange(comment, fileLines)
+	if err != nil {
+		return err
+	}
+
+	var suggestionLines []string
+	if comment.SuggestedCode != "" {
+		suggestionLines = strings.Split(strings.TrimSuffix(comment.SuggestedCode, "\n"), "\n")
+	}
+
+	var newFileLines []string
+	newFileLines = append(newFileLines, fileLines[:targetLine]...)
+	newFileLines = append(newFileLines, suggestionLines...)
+	if targetLine+removeCount < len(fileLines) {
+		newFileLines = append(newFileLines, fileLines[targetLine+removeCount:]...)
+	}
+
+	newContent := strings.Join(newFileLines, "\n")
+	if strings.HasSuffix(string(fileContent), "\n") && !strings.HasSuffix(newContent, "\n") {
+		newContent += "\n"
+	}
+
+	if err := os.WriteFile(comment.Path, []byte(newContent), 0o644); err != nil {
+		return fmt.Errorf("failed to write file %s: %w", comment.Path, err)
+	}
+
+	return nil
+}
+
+// PreviewSuggestion generates a diff preview of what applying the suggestion would change.
+// Returns the diff string without actually modifying the file.
+func (a *Applier) PreviewSuggestion(comment *github.ReviewComment) (string, error) {
+	if err := validatePath(comment.Path); err != nil {
+		return "", err
+	}
+
+	// Read the current file
+	fileContent, err := os.ReadFile(comment.Path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file %s: %w", comment.Path, err)
+	}
+	fileLines := strings.Split(string(fileContent), "\n")
+
+	// Find the lines to replace
+	targetLine, removeCount, err := a.findReplacementTargetByLineRange(comment, fileLines)
+	if err != nil {
+		return "", err
+	}
+
+	// Build a unified diff preview
+	var diff strings.Builder
+	fmt.Fprintf(&diff, "--- a/%s\n", comment.Path)
+	fmt.Fprintf(&diff, "+++ b/%s\n", comment.Path)
+	var suggestionLines []string
+	if comment.SuggestedCode != "" {
+		suggestionLines = strings.Split(strings.TrimSuffix(comment.SuggestedCode, "\n"), "\n")
+	}
+	fmt.Fprintf(&diff, "@@ -%d,%d +%d,%d @@\n",
+		targetLine+1, removeCount,
+		targetLine+1, len(suggestionLines))
+
+	// Show lines being removed
+	for i := 0; i < removeCount; i++ {
+		if targetLine+i < len(fileLines) {
+			fmt.Fprintf(&diff, "-%s\n", fileLines[targetLine+i])
+		}
+	}
+
+	// Show lines being added
+	for _, line := range suggestionLines {
+		fmt.Fprintf(&diff, "+%s\n", line)
+	}
+
+	return diff.String(), nil
+}
+
 // debugLog prints debug messages if debug mode is enabled
 func (a *Applier) debugLog(format string, args ...interface{}) {
 	if a.debug {
 		fmt.Fprintf(os.Stderr, "[DEBUG] "+format+"\n", args...)
 	}
+}
+
+// validatePath checks that the given path does not escape the current working directory.
+// This prevents path traversal attacks where a malicious PR could reference paths
+// like "../../../etc/passwd" to read or write arbitrary files on the system.
+func validatePath(path string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+
+	// Resolve to absolute and clean the path (collapses ../ sequences)
+	absPath := filepath.Clean(filepath.Join(cwd, path))
+	if filepath.IsAbs(path) {
+		absPath = filepath.Clean(path)
+	}
+
+	// The resolved path must be within the working directory
+	if !strings.HasPrefix(absPath, cwd+string(filepath.Separator)) {
+		return fmt.Errorf("path %q resolves outside the repository (%s)", path, cwd)
+	}
+
+	return nil
 }
 
 // ApplyAll applies all suggestions without prompting
@@ -251,6 +364,10 @@ func (a *Applier) promptForAction() string {
 func (a *Applier) applySuggestion(comment *github.ReviewComment) error {
 	a.debugLog("Applying suggestion for comment ID=%d, Path=%s, Line=%d", comment.ID, comment.Path, comment.Line)
 
+	if err := validatePath(comment.Path); err != nil {
+		return err
+	}
+
 	// Read the current file
 	fileContent, err := os.ReadFile(comment.Path)
 	if err != nil {
@@ -300,7 +417,39 @@ func (a *Applier) applySuggestion(comment *github.ReviewComment) error {
 	return nil
 }
 
-// findReplacementTarget identifies the start line and number of lines to replace
+// findReplacementTargetByLineRange uses the comment's StartLine/Line fields
+// to determine the replacement range. Used by Browse view actions.
+func (a *Applier) findReplacementTargetByLineRange(comment *github.ReviewComment, fileLines []string) (int, int, error) {
+	// Use the comment's line range fields to determine what to replace
+	// StartLine and Line define the range of lines the suggestion applies to
+	startLine := comment.StartLine
+	endLine := comment.Line
+
+	// If StartLine is 0, it's a single-line suggestion
+	if startLine == 0 {
+		startLine = endLine
+	}
+
+	a.debugLog("Suggestion targets lines %d-%d (1-based)", startLine, endLine)
+
+	// Convert to 0-based index
+	targetLine := startLine - 1
+	removeCount := endLine - startLine + 1
+
+	// Validate the range
+	if targetLine < 0 || targetLine >= len(fileLines) {
+		return -1, 0, fmt.Errorf("target line %d is out of bounds (file has %d lines)", startLine, len(fileLines))
+	}
+	if targetLine+removeCount > len(fileLines) {
+		return -1, 0, fmt.Errorf("target range %d-%d exceeds file length (%d lines)", startLine, endLine, len(fileLines))
+	}
+
+	return targetLine, removeCount, nil
+}
+
+// findReplacementTarget identifies the start line and number of lines to replace.
+// Uses a two-strategy approach: position mapping from the diff hunk, then content matching.
+// Used by the "apply" subcommand.
 func (a *Applier) findReplacementTarget(comment *github.ReviewComment, fileLines []string) (int, int, error) {
 	// Extract the lines that were added in the PR (+ lines) from DiffHunk
 	// These are the lines we expect to find in the local file and replace
@@ -523,6 +672,10 @@ func (a *Applier) showGitDiff(filePath string) {
 // applyWithAI uses AI to apply a suggestion intelligently
 func (a *Applier) applyWithAI(comment *github.ReviewComment, autoApply bool) error {
 	ctx := context.Background()
+
+	if err := validatePath(comment.Path); err != nil {
+		return err
+	}
 
 	// Read current file
 	fileContent, err := os.ReadFile(comment.Path)

--- a/pkg/applier/applier_test.go
+++ b/pkg/applier/applier_test.go
@@ -1,0 +1,640 @@
+package applier
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gh-tui-tools/gh-review-conductor/pkg/github"
+)
+
+func TestFindReplacementTargetByLineRange(t *testing.T) {
+	a := New()
+	fileLines := []string{"line1", "line2", "line3", "line4", "line5"}
+
+	tests := []struct {
+		name            string
+		comment         *github.ReviewComment
+		wantTargetLine  int
+		wantRemoveCount int
+		wantErr         bool
+	}{
+		{
+			name: "single-line suggestion (StartLine is 0)",
+			comment: &github.ReviewComment{
+				Line:      3,
+				StartLine: 0,
+			},
+			wantTargetLine:  2,
+			wantRemoveCount: 1,
+		},
+		{
+			name: "multi-line suggestion",
+			comment: &github.ReviewComment{
+				Line:      4,
+				StartLine: 2,
+			},
+			wantTargetLine:  1,
+			wantRemoveCount: 3,
+		},
+		{
+			name: "single-line with StartLine equal to Line",
+			comment: &github.ReviewComment{
+				Line:      1,
+				StartLine: 1,
+			},
+			wantTargetLine:  0,
+			wantRemoveCount: 1,
+		},
+		{
+			name: "last line of file",
+			comment: &github.ReviewComment{
+				Line:      5,
+				StartLine: 0,
+			},
+			wantTargetLine:  4,
+			wantRemoveCount: 1,
+		},
+		{
+			name: "entire file range",
+			comment: &github.ReviewComment{
+				Line:      5,
+				StartLine: 1,
+			},
+			wantTargetLine:  0,
+			wantRemoveCount: 5,
+		},
+		{
+			name: "line beyond file length",
+			comment: &github.ReviewComment{
+				Line:      6,
+				StartLine: 0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "range exceeds file length",
+			comment: &github.ReviewComment{
+				Line:      6,
+				StartLine: 4,
+			},
+			wantErr: true,
+		},
+		{
+			name: "line zero (invalid)",
+			comment: &github.ReviewComment{
+				Line:      0,
+				StartLine: 0,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			targetLine, removeCount, err := a.findReplacementTargetByLineRange(tt.comment, fileLines)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got targetLine=%d, removeCount=%d", targetLine, removeCount)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if targetLine != tt.wantTargetLine {
+				t.Errorf("targetLine = %d, want %d", targetLine, tt.wantTargetLine)
+			}
+			if removeCount != tt.wantRemoveCount {
+				t.Errorf("removeCount = %d, want %d", removeCount, tt.wantRemoveCount)
+			}
+		})
+	}
+}
+
+func TestPreviewSuggestion(t *testing.T) {
+	// Create a temp file with known content
+	dir := t.TempDir()
+	// Resolve symlinks so paths match os.Getwd() on macOS (/var -> /private/var)
+	dir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	filePath := filepath.Join(dir, "test.go")
+	fileContent := "package main\n\nfunc hello() {\n\tfmt.Println(\"hello\")\n}\n"
+	if err := os.WriteFile(filePath, []byte(fileContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// chdir so validatePath accepts the file path
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	a := New()
+
+	tests := []struct {
+		name           string
+		comment        *github.ReviewComment
+		wantContains   []string
+		wantNoContains []string
+		wantErr        bool
+	}{
+		{
+			name: "single-line replacement",
+			comment: &github.ReviewComment{
+				Path:          filePath,
+				Line:          4,
+				StartLine:     0,
+				SuggestedCode: "\tfmt.Println(\"world\")\n",
+			},
+			wantContains: []string{
+				"--- a/",
+				"+++ b/",
+				"@@ -4,1 +4,1 @@",
+				"-\tfmt.Println(\"hello\")",
+				"+\tfmt.Println(\"world\")",
+			},
+		},
+		{
+			name: "multi-line replacement",
+			comment: &github.ReviewComment{
+				Path:          filePath,
+				Line:          4,
+				StartLine:     3,
+				SuggestedCode: "func greet(name string) {\n\tfmt.Printf(\"hello %s\\n\", name)\n",
+			},
+			wantContains: []string{
+				"@@ -3,2 +3,2 @@",
+				"-func hello() {",
+				"-\tfmt.Println(\"hello\")",
+				"+func greet(name string) {",
+				"+\tfmt.Printf(\"hello %s\\n\", name)",
+			},
+		},
+		{
+			name: "expanding replacement (1 line to 3)",
+			comment: &github.ReviewComment{
+				Path:          filePath,
+				Line:          4,
+				StartLine:     0,
+				SuggestedCode: "\tlog.Println(\"a\")\n\tlog.Println(\"b\")\n\tlog.Println(\"c\")\n",
+			},
+			wantContains: []string{
+				"@@ -4,1 +4,3 @@",
+				"-\tfmt.Println(\"hello\")",
+				"+\tlog.Println(\"a\")",
+				"+\tlog.Println(\"b\")",
+				"+\tlog.Println(\"c\")",
+			},
+		},
+		{
+			name: "shrinking replacement (2 lines to 1)",
+			comment: &github.ReviewComment{
+				Path:          filePath,
+				Line:          4,
+				StartLine:     3,
+				SuggestedCode: "func hello() { fmt.Println(\"hello\") }\n",
+			},
+			wantContains: []string{
+				"@@ -3,2 +3,1 @@",
+				"-func hello() {",
+				"-\tfmt.Println(\"hello\")",
+				"+func hello() { fmt.Println(\"hello\") }",
+			},
+		},
+		{
+			name: "first line replacement",
+			comment: &github.ReviewComment{
+				Path:          filePath,
+				Line:          1,
+				StartLine:     0,
+				SuggestedCode: "package greet\n",
+			},
+			wantContains: []string{
+				"@@ -1,1 +1,1 @@",
+				"-package main",
+				"+package greet",
+			},
+		},
+		{
+			name: "empty suggestion shows pure deletion",
+			comment: &github.ReviewComment{
+				Path:          filePath,
+				Line:          4,
+				StartLine:     0,
+				SuggestedCode: "",
+			},
+			wantContains: []string{
+				"@@ -4,1 +4,0 @@",
+				"-\tfmt.Println(\"hello\")",
+			},
+		},
+		{
+			name: "empty suggestion deletes multi-line range",
+			comment: &github.ReviewComment{
+				Path:          filePath,
+				Line:          4,
+				StartLine:     3,
+				SuggestedCode: "",
+			},
+			wantContains: []string{
+				"@@ -3,2 +3,0 @@",
+				"-func hello() {",
+				"-\tfmt.Println(\"hello\")",
+			},
+		},
+		{
+			name: "nonexistent file",
+			comment: &github.ReviewComment{
+				Path:          filepath.Join(dir, "nonexistent.go"),
+				Line:          1,
+				StartLine:     0,
+				SuggestedCode: "replacement\n",
+			},
+			wantErr: true,
+		},
+		{
+			name: "line out of range",
+			comment: &github.ReviewComment{
+				Path:          filePath,
+				Line:          99,
+				StartLine:     0,
+				SuggestedCode: "replacement\n",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diff, err := a.PreviewSuggestion(tt.comment)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got diff:\n%s", diff)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for _, s := range tt.wantContains {
+				if !strings.Contains(diff, s) {
+					t.Errorf("diff missing %q\ngot:\n%s", s, diff)
+				}
+			}
+			for _, s := range tt.wantNoContains {
+				if strings.Contains(diff, s) {
+					t.Errorf("diff should not contain %q\ngot:\n%s", s, diff)
+				}
+			}
+		})
+	}
+}
+
+func TestApplySuggestion(t *testing.T) {
+	tests := []struct {
+		name          string
+		fileContent   string
+		comment       *github.ReviewComment // Path is filled in by test harness
+		wantContent   string
+		wantContains  []string
+		wantAbsent    []string
+	}{
+		{
+			name:        "single-line replacement (StartLine=0)",
+			fileContent: "package main\n\nfunc hello() {\n\tfmt.Println(\"hello\")\n}\n",
+			comment: &github.ReviewComment{
+				Line:          4,
+				StartLine:     0,
+				SuggestedCode: "\tfmt.Println(\"world\")\n",
+			},
+			wantContains: []string{"fmt.Println(\"world\")"},
+			wantAbsent:   []string{"fmt.Println(\"hello\")"},
+		},
+		{
+			name:        "multi-line replacement (3 lines to 2)",
+			fileContent: "line1\nline2\nline3\nline4\nline5\n",
+			comment: &github.ReviewComment{
+				Line:          4,
+				StartLine:     2,
+				SuggestedCode: "replaced_a\nreplaced_b\n",
+			},
+			wantContent: "line1\nreplaced_a\nreplaced_b\nline5\n",
+		},
+		{
+			name:        "multi-line replacement expands (1 line to 3)",
+			fileContent: "aaa\nbbb\nccc\n",
+			comment: &github.ReviewComment{
+				Line:          2,
+				StartLine:     2,
+				SuggestedCode: "x1\nx2\nx3\n",
+			},
+			wantContent: "aaa\nx1\nx2\nx3\nccc\n",
+		},
+		{
+			name:        "multi-line replacement shrinks (3 lines to 1)",
+			fileContent: "aaa\nbbb\nccc\nddd\neee\n",
+			comment: &github.ReviewComment{
+				Line:          4,
+				StartLine:     2,
+				SuggestedCode: "only_one\n",
+			},
+			wantContent: "aaa\nonly_one\neee\n",
+		},
+		{
+			name:        "replace first line",
+			fileContent: "old_first\nsecond\nthird\n",
+			comment: &github.ReviewComment{
+				Line:          1,
+				StartLine:     0,
+				SuggestedCode: "new_first\n",
+			},
+			wantContent: "new_first\nsecond\nthird\n",
+		},
+		{
+			name:        "replace last line",
+			fileContent: "first\nsecond\nold_last\n",
+			comment: &github.ReviewComment{
+				Line:          3,
+				StartLine:     0,
+				SuggestedCode: "new_last\n",
+			},
+			wantContent: "first\nsecond\nnew_last\n",
+		},
+		{
+			name:        "diff hunk is irrelevant to replacement",
+			fileContent: "aaa\nbbb\nccc\n",
+			comment: &github.ReviewComment{
+				Line:      2,
+				StartLine: 0,
+				// DiffHunk references completely different content;
+				// ApplySuggestion uses line ranges, not diff hunk parsing
+				DiffHunk:      "@@ -1,3 +1,3 @@\n zzz\n-wrong\n+also_wrong\n yyy",
+				SuggestedCode: "BBB\n",
+			},
+			wantContent: "aaa\nBBB\nccc\n",
+		},
+		{
+			name:        "empty suggestion deletes multi-line range",
+			fileContent: "aaa\nbbb\nccc\nddd\neee\n",
+			comment: &github.ReviewComment{
+				Line:          4,
+				StartLine:     2,
+				SuggestedCode: "",
+			},
+			wantContent: "aaa\neee\n",
+		},
+		{
+			name:        "preserves trailing newline",
+			fileContent: "aaa\nbbb\n",
+			comment: &github.ReviewComment{
+				Line:          1,
+				StartLine:     0,
+				SuggestedCode: "AAA\n",
+			},
+			wantContent: "AAA\nbbb\n",
+		},
+		{
+			name:        "empty suggestion deletes lines",
+			fileContent: "keep\ndelete_me\nalso_keep\n",
+			comment: &github.ReviewComment{
+				Line:          2,
+				StartLine:     0,
+				SuggestedCode: "",
+			},
+			wantContent: "keep\nalso_keep\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			dir, err := filepath.EvalSymlinks(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			filePath := filepath.Join(dir, "test.go")
+			if err := os.WriteFile(filePath, []byte(tt.fileContent), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			origDir, err := os.Getwd()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = os.Chdir(origDir) }()
+			if err := os.Chdir(dir); err != nil {
+				t.Fatal(err)
+			}
+
+			a := New()
+			comment := tt.comment
+			comment.Path = filePath
+
+			if err := a.ApplySuggestion(comment); err != nil {
+				t.Fatalf("ApplySuggestion failed: %v", err)
+			}
+
+			got, err := os.ReadFile(filePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if tt.wantContent != "" && string(got) != tt.wantContent {
+				t.Errorf("file content mismatch\nwant: %q\ngot:  %q", tt.wantContent, string(got))
+			}
+			for _, s := range tt.wantContains {
+				if !strings.Contains(string(got), s) {
+					t.Errorf("file missing %q\ngot:\n%s", s, string(got))
+				}
+			}
+			for _, s := range tt.wantAbsent {
+				if strings.Contains(string(got), s) {
+					t.Errorf("file should not contain %q\ngot:\n%s", s, string(got))
+				}
+			}
+		})
+	}
+}
+
+func TestFindReplacementTarget(t *testing.T) {
+	a := New()
+
+	tests := []struct {
+		name            string
+		fileLines       []string
+		comment         *github.ReviewComment
+		wantTargetLine  int
+		wantRemoveCount int
+		wantErr         bool
+		wantErrContains string
+	}{
+		{
+			name:      "strategy 1: position mapping finds match",
+			fileLines: []string{"aaa", "bbb", "ccc"},
+			comment: &github.ReviewComment{
+				DiffHunk: "@@ -1,3 +1,3 @@\n aaa\n-old\n+bbb\n ccc",
+			},
+			wantTargetLine:  1,
+			wantRemoveCount: 1,
+		},
+		{
+			name:      "strategy 1: multi-line added lines match",
+			fileLines: []string{"aaa", "b1", "b2", "ccc"},
+			comment: &github.ReviewComment{
+				DiffHunk: "@@ -1,2 +1,4 @@\n aaa\n-old\n+b1\n+b2\n ccc",
+			},
+			wantTargetLine:  1,
+			wantRemoveCount: 2,
+		},
+		{
+			name:      "strategy 2: position mismatch, content found elsewhere",
+			fileLines: []string{"xxx", "yyy", "bbb", "zzz"},
+			comment: &github.ReviewComment{
+				// Position mapping points to index 1, but "bbb" is at index 2
+				DiffHunk: "@@ -1,3 +1,3 @@\n aaa\n-old\n+bbb\n ccc",
+			},
+			wantTargetLine:  2,
+			wantRemoveCount: 1,
+		},
+		{
+			name:      "no added lines in diff hunk",
+			fileLines: []string{"aaa", "ccc"},
+			comment: &github.ReviewComment{
+				DiffHunk: "@@ -1,3 +1,2 @@\n aaa\n-old\n ccc",
+			},
+			wantErr:         true,
+			wantErrContains: "no added lines found",
+		},
+		{
+			name:      "empty diff hunk",
+			fileLines: []string{"aaa", "bbb"},
+			comment: &github.ReviewComment{
+				DiffHunk: "",
+			},
+			wantErr:         true,
+			wantErrContains: "no added lines found",
+		},
+		{
+			name:      "content not found anywhere in file",
+			fileLines: []string{"xxx", "yyy", "zzz"},
+			comment: &github.ReviewComment{
+				DiffHunk: "@@ -1,3 +1,3 @@\n aaa\n-old\n+notfound\n ccc",
+			},
+			wantErr:         true,
+			wantErrContains: "could not find the code to replace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			targetLine, removeCount, err := a.findReplacementTarget(tt.comment, tt.fileLines)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got targetLine=%d, removeCount=%d", targetLine, removeCount)
+				} else if tt.wantErrContains != "" && !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Errorf("error %q should contain %q", err.Error(), tt.wantErrContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if targetLine != tt.wantTargetLine {
+				t.Errorf("targetLine = %d, want %d", targetLine, tt.wantTargetLine)
+			}
+			if removeCount != tt.wantRemoveCount {
+				t.Errorf("removeCount = %d, want %d", removeCount, tt.wantRemoveCount)
+			}
+		})
+	}
+}
+
+func TestValidatePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{
+			name:    "relative path within repo",
+			path:    "pkg/applier/applier.go",
+			wantErr: false,
+		},
+		{
+			name:    "path traversal with dotdot",
+			path:    "../../../etc/passwd",
+			wantErr: true,
+		},
+		{
+			name:    "path traversal hidden in middle",
+			path:    "pkg/../../../../../../etc/shadow",
+			wantErr: true,
+		},
+		{
+			name:    "absolute path outside repo",
+			path:    "/etc/passwd",
+			wantErr: true,
+		},
+		{
+			name:    "absolute path outside repo (home dir)",
+			path:    "/tmp/malicious-file",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePath(tt.path)
+			if tt.wantErr && err == nil {
+				t.Errorf("validatePath(%q) = nil, want error", tt.path)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("validatePath(%q) = %v, want nil", tt.path, err)
+			}
+		})
+	}
+}
+
+func TestApplySuggestionRejectsTraversal(t *testing.T) {
+	a := New()
+	comment := &github.ReviewComment{
+		Path:          "../../../etc/passwd",
+		Line:          1,
+		StartLine:     0,
+		SuggestedCode: "malicious content",
+	}
+
+	err := a.ApplySuggestion(comment)
+	if err == nil {
+		t.Fatal("ApplySuggestion should reject path traversal")
+	}
+	if !strings.Contains(err.Error(), "outside the repository") {
+		t.Errorf("error should mention path is outside repository, got: %v", err)
+	}
+}
+
+func TestPreviewSuggestionRejectsTraversal(t *testing.T) {
+	a := New()
+	comment := &github.ReviewComment{
+		Path:          "../../../etc/passwd",
+		Line:          1,
+		StartLine:     0,
+		SuggestedCode: "malicious content",
+	}
+
+	_, err := a.PreviewSuggestion(comment)
+	if err == nil {
+		t.Fatal("PreviewSuggestion should reject path traversal")
+	}
+	if !strings.Contains(err.Error(), "outside the repository") {
+		t.Errorf("error should mention path is outside repository, got: %v", err)
+	}
+}

--- a/pkg/ui/colors.go
+++ b/pkg/ui/colors.go
@@ -120,6 +120,20 @@ func TruncateDiff(diff string, maxLines int) string {
 	return strings.Join(lines[:maxLines], "\n") + "\n..."
 }
 
+// TruncateDiffTail returns the last maxLines lines of a diff, keeping the
+// lines closest to the comment. If the diff is already short enough, it is
+// returned unchanged.
+func TruncateDiffTail(diff string, maxLines int) string {
+	if maxLines <= 0 {
+		return diff
+	}
+	lines := strings.Split(diff, "\n")
+	if len(lines) <= maxLines {
+		return diff
+	}
+	return "...\n" + strings.Join(lines[len(lines)-maxLines:], "\n")
+}
+
 // ColorizeDiff applies syntax highlighting to diff hunks
 func ColorizeDiff(diff string) string {
 	lines := strings.Split(diff, "\n")

--- a/pkg/ui/colors_test.go
+++ b/pkg/ui/colors_test.go
@@ -620,3 +620,58 @@ func TestFormatReactions(t *testing.T) {
 		})
 	}
 }
+
+func TestTruncateDiffTail(t *testing.T) {
+	tests := []struct {
+		name     string
+		diff     string
+		maxLines int
+		expected string
+	}{
+		{
+			name:     "no truncation needed",
+			diff:     "line1\nline2\nline3",
+			maxLines: 5,
+			expected: "line1\nline2\nline3",
+		},
+		{
+			name:     "exact limit",
+			diff:     "line1\nline2\nline3",
+			maxLines: 3,
+			expected: "line1\nline2\nline3",
+		},
+		{
+			name:     "takes last N lines",
+			diff:     "line1\nline2\nline3\nline4\nline5",
+			maxLines: 3,
+			expected: "...\nline3\nline4\nline5",
+		},
+		{
+			name:     "zero maxLines means no truncation",
+			diff:     "line1\nline2\nline3",
+			maxLines: 0,
+			expected: "line1\nline2\nline3",
+		},
+		{
+			name:     "negative maxLines means no truncation",
+			diff:     "line1\nline2",
+			maxLines: -1,
+			expected: "line1\nline2",
+		},
+		{
+			name:     "single line no truncation",
+			diff:     "single",
+			maxLines: 1,
+			expected: "single",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := TruncateDiffTail(tt.diff, tt.maxLines)
+			if result != tt.expected {
+				t.Errorf("TruncateDiffTail(%q, %d) = %q, want %q", tt.diff, tt.maxLines, result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/ui/selector.go
+++ b/pkg/ui/selector.go
@@ -114,9 +114,18 @@ type SelectorOptions[T any] struct {
 	EditKey    string // e.g., "e edit"
 
 	// Action: x (add reaction)
-	ReactionAction   func(T) (int64, error)                                       // Returns comment ID to react to
+	ReactionAction   func(T) (int64, error)                                                      // Returns comment ID to react to
 	ReactionComplete func(item T, commentID int64, apiName, displayEmoji string) (string, error) // Applies reaction, returns confirmation message
-	ReactionKey      string                                                       // e.g., "x react"
+	ReactionKey      string                                                                      // e.g., "x react"
+
+	// Action: s (apply suggestion)
+	ApplySuggestionPreview CustomAction[T] // Returns diff preview string
+	ApplySuggestionAction  CustomAction[T] // Actually applies the suggestion
+	ApplySuggestionKey     string          // e.g., "s apply"
+
+	// Action: S (apply suggestion and resolve)
+	ApplySuggestionResolveAction CustomAction[T]
+	ApplySuggestionResolveKey    string // e.g., "S apply+resolve"
 }
 
 // SelectionModel is the tea.Model for interactive selection
@@ -160,6 +169,12 @@ type SelectionModel[T any] struct {
 	reactionIdx       int         // current emoji index (0-7)
 	reactionCommentID int64       // comment ID to react to
 	reactionItem      listItem[T] // the item being reacted to
+
+	// Apply suggestion preview state
+	applyPreviewMode       bool        // true when showing apply preview
+	applyPreviewDiff       string      // the diff to show
+	applyPreviewItem       listItem[T] // the item being applied
+	applyPreviewWithResolve bool       // true if should also resolve after applying
 }
 
 // listItem wraps a generic item for the list model

--- a/pkg/ui/selector_impl.go
+++ b/pkg/ui/selector_impl.go
@@ -220,6 +220,41 @@ func (m SelectionModel[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
+		// Handle apply suggestion preview mode
+		if m.applyPreviewMode {
+			switch msg.String() {
+			case "y", "Y":
+				// Confirm and apply the suggestion
+				m.applyPreviewMode = false
+				var action CustomAction[T]
+				if m.applyPreviewWithResolve {
+					action = m.opts.ApplySuggestionResolveAction
+				} else {
+					action = m.opts.ApplySuggestionAction
+				}
+				if action != nil {
+					statusMsg, err := action(m.applyPreviewItem.value)
+					if err != nil {
+						m.confirmationMessage = fmt.Sprintf("%s\n\nPress any key to continue...", Colorize(ColorRed, err.Error()))
+						return m, nil
+					}
+					if statusMsg != "" {
+						m.confirmationMessage = fmt.Sprintf("%s\n\nPress any key to continue...", statusMsg)
+						return m, nil
+					}
+				}
+				return m, nil
+			case "esc", "n", "N":
+				// Cancel
+				m.applyPreviewMode = false
+				return m, m.list.NewStatusMessage("Apply cancelled")
+			default:
+				// Any other key cancels
+				m.applyPreviewMode = false
+				return m, m.list.NewStatusMessage("Apply cancelled")
+			}
+		}
+
 		// Handle comment selection mode
 		if m.commentSelectMode {
 			switch msg.String() {
@@ -347,6 +382,12 @@ func (m SelectionModel[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "x":
 				// Add reaction from detail view
 				return m.handleReactionKey(true)
+			case "s":
+				// Apply suggestion from detail view (with preview)
+				return m.startApplyPreview(false)
+			case "S":
+				// Apply suggestion and resolve from detail view (with preview)
+				return m.startApplyPreview(true)
 			case "i":
 				// Refresh from detail view
 				return m.startRefresh()
@@ -494,6 +535,12 @@ func (m SelectionModel[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 			return m, nil
+		case "s":
+			// Apply suggestion (with preview)
+			return m.startApplyPreview(false)
+		case "S":
+			// Apply suggestion and resolve (with preview)
+			return m.startApplyPreview(true)
 		case "x":
 			// Add reaction
 			return m.handleReactionKey(false)
@@ -504,6 +551,37 @@ func (m SelectionModel[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	m.list, cmd = m.list.Update(msg)
 	return m, cmd
+}
+
+// startApplyPreview initiates the apply suggestion preview mode
+func (m *SelectionModel[T]) startApplyPreview(withResolve bool) (tea.Model, tea.Cmd) {
+	if m.opts.ApplySuggestionPreview == nil {
+		// No preview configured, show error
+		m.confirmationMessage = fmt.Sprintf("%s\n\nPress any key to continue...", Colorize(ColorRed, "Apply preview not configured"))
+		return m, nil
+	}
+
+	selected := m.list.SelectedItem()
+	if selected == nil {
+		return m, nil
+	}
+
+	item := selected.(listItem[T])
+
+	// Get the preview diff
+	diffPreview, err := m.opts.ApplySuggestionPreview(item.value)
+	if err != nil {
+		m.confirmationMessage = fmt.Sprintf("%s\n\nPress any key to continue...", Colorize(ColorRed, err.Error()))
+		return m, nil
+	}
+
+	// Enter preview mode
+	m.applyPreviewMode = true
+	m.applyPreviewDiff = diffPreview
+	m.applyPreviewItem = item
+	m.applyPreviewWithResolve = withResolve
+
+	return m, nil
 }
 
 // editInEditor opens the given file path in the user's editor at the specified line
@@ -706,6 +784,10 @@ func (m SelectionModel[T]) View() string {
 		return m.renderConfirmation()
 	}
 
+	if m.applyPreviewMode {
+		return m.renderApplyPreview()
+	}
+
 	if m.showDetail {
 		titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("205"))
 		helpStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
@@ -740,6 +822,14 @@ func (m SelectionModel[T]) View() string {
 		if m.opts.ReactionAction != nil {
 			key, _ := splitActionKey(m.opts.ReactionKey)
 			actions = append(actions, key+":react")
+		}
+		if m.opts.ApplySuggestionAction != nil {
+			key, _ := splitActionKey(m.opts.ApplySuggestionKey)
+			actions = append(actions, key+":apply")
+		}
+		if m.opts.ApplySuggestionResolveAction != nil {
+			key, _ := splitActionKey(m.opts.ApplySuggestionResolveKey)
+			actions = append(actions, key+":apply+resolve")
 		}
 		if m.opts.OnOpen != nil {
 			actions = append(actions, "o:open")
@@ -821,6 +911,14 @@ func (m SelectionModel[T]) View() string {
 		key, _ := splitActionKey(m.opts.ReactionKey)
 		actions = append(actions, key+":react")
 	}
+	if m.opts.ApplySuggestionAction != nil {
+		key, _ := splitActionKey(m.opts.ApplySuggestionKey)
+		actions = append(actions, key+":apply")
+	}
+	if m.opts.ApplySuggestionResolveAction != nil {
+		key, _ := splitActionKey(m.opts.ApplySuggestionResolveKey)
+		actions = append(actions, key+":apply+resolve")
+	}
 	if m.opts.OnOpen != nil {
 		actions = append(actions, "o:open")
 	}
@@ -852,6 +950,53 @@ func (m SelectionModel[T]) View() string {
 
 	return lipgloss.JoinVertical(lipgloss.Left,
 		m.list.View(),
+		"",
+		footer,
+	)
+}
+
+func (m SelectionModel[T]) renderApplyPreview() string {
+	height := m.windowSize.Height
+	if height == 0 {
+		height = 24
+	}
+
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("205"))
+	helpStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+
+	// Header
+	actionText := "Apply Suggestion"
+	if m.applyPreviewWithResolve {
+		actionText = "Apply Suggestion + Resolve"
+	}
+	header := titleStyle.Render(actionText) + "  " + helpStyle.Render("Press 'y' to apply, any other key to cancel")
+
+	// Footer
+	footer := helpStyle.Render("y:apply | any other key:cancel")
+
+	// Colorize the diff
+	coloredDiff := ColorizeDiff(m.applyPreviewDiff)
+
+	// Calculate available height for diff
+	headerHeight := lipgloss.Height(header) + 1
+	footerHeight := lipgloss.Height(footer) + 1
+	availableHeight := height - headerHeight - footerHeight - 2
+
+	// Truncate if too long
+	diffLines := strings.Split(coloredDiff, "\n")
+	if availableHeight < 2 {
+		availableHeight = 2
+	}
+	if len(diffLines) > availableHeight {
+		diffLines = diffLines[:availableHeight-1]
+		diffLines = append(diffLines, helpStyle.Render("... (diff truncated)"))
+	}
+	displayDiff := strings.Join(diffLines, "\n")
+
+	return lipgloss.JoinVertical(lipgloss.Left,
+		header,
+		"",
+		displayDiff,
 		"",
 		footer,
 	)
@@ -956,6 +1101,14 @@ Actions:`
 	}
 	if m.opts.ReactionAction != nil {
 		key, desc := splitActionKey(m.opts.ReactionKey)
+		helpText += fmt.Sprintf("\n  %-12s %s", key, desc)
+	}
+	if m.opts.ApplySuggestionAction != nil {
+		key, desc := splitActionKey(m.opts.ApplySuggestionKey)
+		helpText += fmt.Sprintf("\n  %-12s %s", key, desc)
+	}
+	if m.opts.ApplySuggestionResolveAction != nil {
+		key, desc := splitActionKey(m.opts.ApplySuggestionResolveKey)
 		helpText += fmt.Sprintf("\n  %-12s %s", key, desc)
 	}
 	if m.opts.OnOpen != nil {


### PR DESCRIPTION
Apply commit suggestions in Browse view with “s” and “S” keys

- Add `s` and `S` key bindings to the Browse view, for applying code suggestions directly to local files
- `s` applies the suggestion; `S` applies and resolves the thread
- Shows a diff preview before applying, requiring a keypress to confirm
- Detail view now shows the actual unified diff for suggestions (with removed/added lines) — rather than just the replacement text
- Context section shows the _last_ N lines of the diff hunk (nearest to the comment) rather than the _first_ N — matching GitHub’s web UI
- Browse view actions use the comment’s StartLine/Line fields directly to determine the replacement range; the `apply` subcommand retains its existing two-strategy approach (position mapping from the diff hunk, with content-matching fallback)