### PR TITLE
fix: correct the Browse item tally and hide empty file headings

### DIFF
--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -114,20 +114,7 @@ func runBrowse(cmd *cobra.Command, args []string) error {
 
 		// Filter function (hide resolved and collapsed)
 		filterFunc := func(item BrowseItem, hideResolved bool) bool {
-			// 1. Check collapse state (Always applies)
-			if (item.Type == "comment" || item.Type == "comment_preview") && collapsedFiles[item.Path] {
-				return false
-			}
-
-			// 2. Check resolved state (Only if hideResolved is true)
-			if hideResolved {
-				if item.Type == "file" {
-					return true // Always show headers
-				}
-				return !item.Comment.IsResolved()
-			}
-
-			return true
+			return browseFilter(item, hideResolved, collapsedFiles)
 		}
 
 		// Handle selection (Enter key)
@@ -531,7 +518,31 @@ type BrowseItem struct {
 	Path               string
 	Comment            *github.ReviewComment
 	IsPreview          bool
-	SelectedCommentIdx int // 0 = main comment, 1+ = thread reply index
+	SelectedCommentIdx int  // 0 = main comment, 1+ = thread reply index
+	HasUnresolved      bool // for "file" headers: whether the file has any unresolved comment
+}
+
+// browseFilter reports whether item should be visible, given whether resolved
+// comments are hidden and which files are collapsed.
+func browseFilter(item BrowseItem, hideResolved bool, collapsedFiles map[string]bool) bool {
+	if item.Type == "file" {
+		// A header for a file with nothing left to show would stand alone
+		// above an empty section.
+		if hideResolved {
+			return item.HasUnresolved
+		}
+		return true
+	}
+
+	if collapsedFiles[item.Path] {
+		return false
+	}
+
+	if hideResolved {
+		return !item.Comment.IsResolved()
+	}
+
+	return true
 }
 
 // browseCountable reports whether item is a review comment rather than a row
@@ -577,14 +588,24 @@ func buildCommentTree(comments []*github.ReviewComment) []BrowseItem {
 	var items []BrowseItem
 
 	for _, path := range filePaths {
+		fileComments := files[path]
+
+		hasUnresolved := false
+		for _, c := range fileComments {
+			if !c.IsResolved() {
+				hasUnresolved = true
+				break
+			}
+		}
+
 		// Add File Header
 		items = append(items, BrowseItem{
-			Type: "file",
-			Path: path,
+			Type:          "file",
+			Path:          path,
+			HasUnresolved: hasUnresolved,
 		})
 
 		// Sort comments in this file by line
-		fileComments := files[path]
 		for i := 0; i < len(fileComments); i++ {
 			for j := i + 1; j < len(fileComments); j++ {
 				if fileComments[i].Line > fileComments[j].Line {

--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -391,6 +391,7 @@ func runBrowse(cmd *cobra.Command, args []string) error {
 			FilterDefault:  true, // Hide resolved comments by default
 			IsItemResolved: isItemResolved,
 			RefreshItems:   refreshItems,
+			CountableItem:  browseCountable,
 
 			// r/u key: resolve/unresolve
 			ResolveAction: resolveAction,
@@ -531,6 +532,12 @@ type BrowseItem struct {
 	Comment            *github.ReviewComment
 	IsPreview          bool
 	SelectedCommentIdx int // 0 = main comment, 1+ = thread reply index
+}
+
+// browseCountable reports whether item is a review comment rather than a row
+// that exists only for layout, such as a file header or a preview row.
+func browseCountable(item BrowseItem) bool {
+	return item.Type == "comment"
 }
 
 // buildCommentTree converts a flat list of comments into a tree-like structure

--- a/cmd/browse_test.go
+++ b/cmd/browse_test.go
@@ -540,6 +540,61 @@ func TestPreviewWithHighlight_ContextShowsTail(t *testing.T) {
 	}
 }
 
+func TestBuildCommentTreeMarksFileHeaderResolvedState(t *testing.T) {
+	comments := []*github.ReviewComment{
+		{ID: 1, Path: "open.go", Line: 10},
+		{ID: 2, Path: "done.go", Line: 20, SubjectType: "resolved"},
+		{ID: 3, Path: "mixed.go", Line: 30, SubjectType: "resolved"},
+		{ID: 4, Path: "mixed.go", Line: 40},
+	}
+
+	headers := make(map[string]BrowseItem)
+	for _, item := range buildCommentTree(comments) {
+		if item.Type == "file" {
+			headers[item.Path] = item
+		}
+	}
+
+	for path, want := range map[string]bool{"open.go": true, "done.go": false, "mixed.go": true} {
+		if got := headers[path].HasUnresolved; got != want {
+			t.Errorf("header %s HasUnresolved = %v, want %v", path, got, want)
+		}
+	}
+}
+
+func TestBrowseFilterHidesFileHeadersWithNoUnresolvedComments(t *testing.T) {
+	collapsed := map[string]bool{}
+
+	openHeader := BrowseItem{Type: "file", Path: "open.go", HasUnresolved: true}
+	doneHeader := BrowseItem{Type: "file", Path: "done.go"}
+
+	if !browseFilter(openHeader, true, collapsed) {
+		t.Error("header with unresolved comments should stay visible when hiding resolved")
+	}
+	if browseFilter(doneHeader, true, collapsed) {
+		t.Error("header with only resolved comments should be hidden when hiding resolved")
+	}
+	if !browseFilter(doneHeader, false, collapsed) {
+		t.Error("header should stay visible when resolved comments are shown")
+	}
+}
+
+func TestBrowseFilterHidesCollapsedAndResolvedComments(t *testing.T) {
+	resolved := &github.ReviewComment{ID: 1, Path: "a.go", SubjectType: "resolved"}
+	open := &github.ReviewComment{ID: 2, Path: "a.go"}
+	collapsed := map[string]bool{"b.go": true}
+
+	if browseFilter(BrowseItem{Type: "comment", Path: "a.go", Comment: resolved}, true, collapsed) {
+		t.Error("resolved comment should be hidden when hiding resolved")
+	}
+	if !browseFilter(BrowseItem{Type: "comment", Path: "a.go", Comment: open}, true, collapsed) {
+		t.Error("unresolved comment should stay visible when hiding resolved")
+	}
+	if browseFilter(BrowseItem{Type: "comment_preview", Path: "b.go", Comment: open}, false, collapsed) {
+		t.Error("preview row in a collapsed file should be hidden")
+	}
+}
+
 func TestBrowseCountsOnlyCommentRows(t *testing.T) {
 	items := buildCommentTree([]*github.ReviewComment{
 		{ID: 1, Path: "a.go", Line: 10},

--- a/cmd/browse_test.go
+++ b/cmd/browse_test.go
@@ -539,3 +539,21 @@ func TestPreviewWithHighlight_ContextShowsTail(t *testing.T) {
 		t.Errorf("preview context should not show lines from start of long hunk, got:\n%s", preview)
 	}
 }
+
+func TestBrowseCountsOnlyCommentRows(t *testing.T) {
+	items := buildCommentTree([]*github.ReviewComment{
+		{ID: 1, Path: "a.go", Line: 10},
+		{ID: 2, Path: "b.go", Line: 20},
+	})
+
+	count := 0
+	for _, item := range items {
+		if browseCountable(item) {
+			count++
+		}
+	}
+
+	if count != 2 {
+		t.Errorf("browseCountable matched %d of %d rows, want 2", count, len(items))
+	}
+}

--- a/pkg/ui/selector.go
+++ b/pkg/ui/selector.go
@@ -84,6 +84,12 @@ type SelectorOptions[T any] struct {
 	IsItemResolved func(T) bool        // For dynamic key display (r vs u)
 	RefreshItems   func() ([]T, error) // Called when 'i' is pressed
 
+	// CountableItem reports whether an item counts toward the tally shown
+	// above the list. Rows that exist only for layout, such as group headers
+	// and preview rows, return false so the tally reflects real entries.
+	// When nil, every visible row counts.
+	CountableItem func(T) bool
+
 	// Action: r/u (resolve toggle)
 	ResolveAction CustomAction[T]
 	ResolveKey    string // e.g., "r resolve"
@@ -171,10 +177,10 @@ type SelectionModel[T any] struct {
 	reactionItem      listItem[T] // the item being reacted to
 
 	// Apply suggestion preview state
-	applyPreviewMode       bool        // true when showing apply preview
-	applyPreviewDiff       string      // the diff to show
-	applyPreviewItem       listItem[T] // the item being applied
-	applyPreviewWithResolve bool       // true if should also resolve after applying
+	applyPreviewMode        bool        // true when showing apply preview
+	applyPreviewDiff        string      // the diff to show
+	applyPreviewItem        listItem[T] // the item being applied
+	applyPreviewWithResolve bool        // true if should also resolve after applying
 }
 
 // listItem wraps a generic item for the list model

--- a/pkg/ui/selector_impl.go
+++ b/pkg/ui/selector_impl.go
@@ -58,20 +58,7 @@ func SelectFromListWithAction[T any](items []T, renderer ItemRenderer[T], custom
 // Select creates an interactive selector with the given options.
 // This is the primary API for creating selectors.
 func Select[T any](opts SelectorOptions[T]) (T, error) {
-	// Convert items to list items
-	listItems := make([]list.Item, len(opts.Items))
-	for i, item := range opts.Items {
-		listItems[i] = listItem[T]{value: item, item: opts.Renderer}
-	}
-
-	delegate := itemDelegate[T]{renderer: opts.Renderer}
-	l := list.New(listItems, delegate, 0, 0)
-	l.SetShowStatusBar(true)
-	l.SetFilteringEnabled(true)
-	l.SetShowHelp(false)
-	l.Styles.Title = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("205"))
-	l.Styles.StatusBar = lipgloss.NewStyle().Padding(0, 1)
-	l.KeyMap.Quit.SetKeys()
+	l := newSelectorList(opts.Items, opts, 0, 0)
 
 	m := SelectionModel[T]{
 		list:         l,
@@ -99,6 +86,26 @@ func Select[T any](opts SelectorOptions[T]) (T, error) {
 		return zero, ErrNoSelection
 	}
 	return final.result[0], nil
+}
+
+// newSelectorList builds the bubbles list model backing a selector.
+func newSelectorList[T any](items []T, opts SelectorOptions[T], width, height int) list.Model {
+	listItems := make([]list.Item, len(items))
+	for i, item := range items {
+		listItems[i] = listItem[T]{value: item, item: opts.Renderer}
+	}
+
+	l := list.New(listItems, itemDelegate[T]{renderer: opts.Renderer}, width, height)
+	// The tally above the list is rendered from countSummary, which counts
+	// entries. The built-in status bar counts rendered rows, so a tree that
+	// emits group headers and preview rows would overstate the total.
+	l.SetShowStatusBar(false)
+	l.SetFilteringEnabled(true)
+	l.SetShowHelp(false)
+	l.Styles.Title = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("205"))
+	l.Styles.StatusBar = lipgloss.NewStyle().Padding(0, 1)
+	l.KeyMap.Quit.SetKeys()
+	return l
 }
 
 // Init initializes the model
@@ -733,6 +740,39 @@ func (m *SelectionModel[T]) updateVisibleItems() {
 	m.list.SetItems(listItems)
 }
 
+// countSummary renders the item tally shown above the list.
+func (m SelectionModel[T]) countSummary() string {
+	countable := m.opts.CountableItem
+	if countable == nil {
+		countable = func(T) bool { return true }
+	}
+
+	visible := 0
+	for _, listed := range m.list.VisibleItems() {
+		if item, ok := listed.(listItem[T]); ok && countable(item.value) {
+			visible++
+		}
+	}
+
+	total := 0
+	for _, item := range m.items {
+		if countable(item) {
+			total++
+		}
+	}
+
+	name := "items"
+	if visible == 1 {
+		name = "item"
+	}
+	summary := fmt.Sprintf("%d %s", visible, name)
+
+	if hidden := total - visible; hidden > 0 {
+		summary += fmt.Sprintf(" · %d filtered", hidden)
+	}
+	return summary
+}
+
 // startRefresh initiates an async refresh if RefreshItems is configured and not already refreshing
 func (m *SelectionModel[T]) startRefresh() (tea.Model, tea.Cmd) {
 	if m.opts.RefreshItems != nil && !m.refreshing {
@@ -947,6 +987,8 @@ func (m SelectionModel[T]) View() string {
 	} else {
 		footer = helpStyle.Render(strings.Join(actions, " | "))
 	}
+
+	m.list.Title = m.countSummary()
 
 	return lipgloss.JoinVertical(lipgloss.Left,
 		m.list.View(),

--- a/pkg/ui/selector_test.go
+++ b/pkg/ui/selector_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -1095,16 +1094,7 @@ func (r mockRenderer) WithSelectedComment(item string, idx int) string    { retu
 
 // newTestModel creates a SelectionModel suitable for testing
 func newTestModel(items []string, opts SelectorOptions[string]) SelectionModel[string] {
-	listItems := make([]list.Item, len(items))
-	for i, item := range items {
-		listItems[i] = listItem[string]{value: item, item: opts.Renderer}
-	}
-
-	delegate := itemDelegate[string]{renderer: opts.Renderer}
-	l := list.New(listItems, delegate, 80, 24)
-	l.SetShowStatusBar(true)
-	l.SetFilteringEnabled(true)
-	l.SetShowHelp(false)
+	l := newSelectorList(items, opts, 80, 24)
 
 	return SelectionModel[string]{
 		list:         l,
@@ -1392,5 +1382,80 @@ func TestRefreshingStateBlocksMultipleRefreshes(t *testing.T) {
 	// Only one call should have been made
 	if callCount != 1 {
 		t.Errorf("Expected exactly 1 RefreshItems call, got %d", callCount)
+	}
+}
+
+func TestCountableItemStatusCount(t *testing.T) {
+	// Mirrors the browse tree shape: one non-countable header row, then a
+	// countable row plus a non-countable preview row per entry.
+	allItems := []string{"file:x", "c:1", "p:1", "c:2", "p:2"}
+
+	opts := SelectorOptions[string]{
+		Items:    allItems,
+		Renderer: mockRenderer{previewContent: "preview"},
+		FilterFunc: func(item string, hide bool) bool {
+			if !hide {
+				return true
+			}
+			return !strings.HasSuffix(item, ":2")
+		},
+		FilterDefault: true,
+		CountableItem: func(item string) bool {
+			return strings.HasPrefix(item, "c:")
+		},
+	}
+
+	m := newTestModel(allItems, opts)
+	m.updateVisibleItems()
+
+	if got := len(m.list.Items()); got != 3 {
+		t.Fatalf("list holds %d rows, want 3 (header + c:1 + p:1)", got)
+	}
+
+	got := m.countSummary()
+	want := "1 item · 1 filtered"
+	if got != want {
+		t.Errorf("countSummary() = %q, want %q", got, want)
+	}
+}
+
+func TestCountableItemStatusCountNilCountsEveryRow(t *testing.T) {
+	items := []string{"a", "b", "c"}
+	m := newTestModel(items, SelectorOptions[string]{
+		Items:    items,
+		Renderer: mockRenderer{previewContent: "preview"},
+	})
+
+	if got, want := m.countSummary(), "3 items"; got != want {
+		t.Errorf("countSummary() = %q, want %q", got, want)
+	}
+}
+
+func TestListViewShowsCountableTallyNotRowCount(t *testing.T) {
+	allItems := []string{"file:x", "c:1", "p:1", "c:2", "p:2"}
+
+	m := newTestModel(allItems, SelectorOptions[string]{
+		Items:    allItems,
+		Renderer: mockRenderer{previewContent: "preview"},
+		FilterFunc: func(item string, hide bool) bool {
+			if !hide {
+				return true
+			}
+			return !strings.HasSuffix(item, ":2")
+		},
+		FilterDefault: true,
+		CountableItem: func(item string) bool {
+			return strings.HasPrefix(item, "c:")
+		},
+	})
+	m.updateVisibleItems()
+
+	view := m.View()
+
+	if want := "1 item · 1 filtered"; !strings.Contains(view, want) {
+		t.Errorf("View() does not contain %q\n%s", want, view)
+	}
+	if strings.Contains(view, "3 items") {
+		t.Errorf("View() still reports the raw row count %q\n%s", "3 items", view)
 	}
 }


### PR DESCRIPTION
**Problem:** Browsing a pull request that has 9 unresolved review comments shows “25 items” at the top of the Browse view, so the tally gives no usable sense of how much feedback is left to work through.

With resolved comments hidden, the Browse view also prints a heading for every file that carries any comment at all, so a file whose comments are all resolved shows up as a heading with nothing beneath it.

**Cause:** `buildCommentTree()` in `cmd/browse.go` emits three kinds of row — one heading per file path, plus a comment row and a skippable preview row for each comment — while the tally comes from the `bubbles` list status bar, which reports the length of `VisibleItems()` and cannot tell content rows from layout rows. Nine unresolved comments spread across seven files therefore render as `7 + 9 + 9 = 25` rows.

The stray headings come from the filter closure in `runBrowse()`, which returned true for every row of type `"file"` whether or not any of that file’s comments survived the filter, on the assumption that a heading is always worth showing.

**Fix:** `SelectorOptions` gains a `CountableItem` predicate, and `countSummary()` counts only matching entries in both the visible rows and the full item set, so the total and the filtered remainder are expressed in the same unit. The `bubbles` status bar is switched off and the tally is rendered in the title row instead, since `bubbles` offers no way to insert a line between the two. Browse supplies `browseCountable()`, which matches rows of type `"comment"` alone. List construction moves into `newSelectorList()` so that the selector and its tests build the model the same way.

File rows carry a `HasUnresolved` flag computed in `buildCommentTree()`, and the filter drops a heading once its file has nothing left to show. The filter moves out of `runBrowse()` into `browseFilter()` so that it can be tested directly. Keeping the flag on the row rather than closing over the comment slice leaves `browseFilter()` free of state that the refresh goroutine would otherwise race.
