### PR TITLE
feat: clickable Browse excerpts, plus row-truncation and refresh fixes

### DIFF
--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/gh-tui-tools/gh-review-conductor/pkg/applier"
 	"github.com/gh-tui-tools/gh-review-conductor/pkg/github"
 	"github.com/gh-tui-tools/gh-review-conductor/pkg/ui"
@@ -672,13 +673,18 @@ func (r *browseItemRenderer) Title(item BrowseItem) string {
 		preview := "..."
 		if len(lines) > 0 {
 			preview = lines[0]
-			if len(preview) > 80 {
-				preview = preview[:77] + "..."
+			// Truncate on visible columns so that a multi-byte rune is
+			// never sliced in half.
+			if ansi.StringWidth(preview) > 80 {
+				preview = ansi.Truncate(preview, 80, "...")
 			} else if len(lines) > 1 {
 				preview += "..."
 			}
 		}
-		return "      " + ui.Colorize(ui.ColorGray, preview)
+		// The indent stays outside the link so that only the excerpt itself
+		// is clickable.
+		excerpt := ui.CreateHyperlink(item.Comment.HTMLURL, ui.Colorize(ui.ColorGray, preview))
+		return "      " + excerpt
 	}
 
 	// Comment Metadata

--- a/cmd/browse_test.go
+++ b/cmd/browse_test.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/gh-tui-tools/gh-review-conductor/pkg/applier"
 	"github.com/gh-tui-tools/gh-review-conductor/pkg/github"
@@ -610,5 +611,73 @@ func TestBrowseCountsOnlyCommentRows(t *testing.T) {
 
 	if count != 2 {
 		t.Errorf("browseCountable matched %d of %d rows, want 2", count, len(items))
+	}
+}
+
+// osc8Re matches an OSC8 hyperlink sequence, which the CSI-only regex used
+// elsewhere in this file does not cover.
+var osc8Re = regexp.MustCompile("\x1b\\]8;;[^\x1b]*\x1b\\\\")
+
+// stripTerminalEscapes removes both OSC8 hyperlinks and CSI color codes.
+func stripTerminalEscapes(s string) string {
+	s = osc8Re.ReplaceAllString(s, "")
+	return regexp.MustCompile("\x1b\\[[0-9;]*m").ReplaceAllString(s, "")
+}
+
+func previewItem(body, htmlURL string) BrowseItem {
+	return BrowseItem{
+		Type:      "comment_preview",
+		Path:      "src/main.go",
+		IsPreview: true,
+		Comment: &github.ReviewComment{
+			ID:      456,
+			Author:  "reviewer",
+			Body:    body,
+			HTMLURL: htmlURL,
+		},
+	}
+}
+
+func newPreviewRenderer() *browseItemRenderer {
+	return &browseItemRenderer{
+		repo:           "owner/repo",
+		prNumber:       123,
+		collapsedFiles: make(map[string]bool),
+	}
+}
+
+func TestBrowseItemRenderer_PreviewExcerptLinksToComment(t *testing.T) {
+	const url = "https://github.com/owner/repo/pull/123#discussion_r456"
+
+	title := newPreviewRenderer().Title(previewItem("Consider using TRY() here", url))
+
+	if !strings.Contains(title, "\x1b]8;;"+url+"\x1b\\") {
+		t.Errorf("excerpt should open an OSC8 link to %s, got %q", url, title)
+	}
+	if !strings.Contains(title, "\x1b]8;;\x1b\\") {
+		t.Errorf("excerpt should close its OSC8 link, got %q", title)
+	}
+	if !strings.HasPrefix(title, "      ") {
+		t.Errorf("the indent should stay outside the link, got %q", title)
+	}
+}
+
+func TestBrowseItemRenderer_PreviewExcerptWithoutURLIsNotLinked(t *testing.T) {
+	title := newPreviewRenderer().Title(previewItem("Consider using TRY() here", ""))
+
+	if strings.Contains(title, "\x1b]8;;") {
+		t.Errorf("excerpt with no URL should carry no OSC8 link, got %q", title)
+	}
+}
+
+func TestBrowseItemRenderer_PreviewExcerptTruncatesOnRuneBoundary(t *testing.T) {
+	// A body of multi-byte runes is far longer in bytes than in columns, so a
+	// byte-based cap slices a rune in half and renders as mojibake.
+	body := strings.Repeat("\u65e5", 100)
+
+	plain := stripTerminalEscapes(newPreviewRenderer().Title(previewItem(body, "")))
+
+	if !utf8.ValidString(plain) {
+		t.Errorf("excerpt truncation split a rune: %q", plain)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.4
 	github.com/charmbracelet/glamour v0.6.0
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.8.0
 	github.com/cli/go-gh/v2 v2.4.0
 	github.com/google/generative-ai-go v0.20.1
 	github.com/muesli/reflow v0.3.0
@@ -28,7 +29,6 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/x/ansi v0.8.0 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/cli/safeexec v1.0.0 // indirect

--- a/pkg/ui/selector_impl.go
+++ b/pkg/ui/selector_impl.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // reactionEmojis defines the available emoji reactions for GitHub comments
@@ -1233,15 +1234,13 @@ func (d itemDelegate[T]) Render(w io.Writer, m list.Model, index int, item list.
 	title := i.Title()
 	desc := i.Description()
 
-	// Truncate if needed
+	// Truncate on visible columns. ANSI escapes occupy bytes but no
+	// columns, so a byte-based cut both undercounts the room available and
+	// can slice through an escape sequence.
 	maxWidth := m.Width() - 4
 	if maxWidth > 0 {
-		if len(title) > maxWidth {
-			title = title[:maxWidth-3] + "..."
-		}
-		if len(desc) > maxWidth {
-			desc = desc[:maxWidth-3] + "..."
-		}
+		title = ansi.Truncate(title, maxWidth, "...")
+		desc = ansi.Truncate(desc, maxWidth, "...")
 	}
 
 	var line string

--- a/pkg/ui/selector_impl.go
+++ b/pkg/ui/selector_impl.go
@@ -163,7 +163,7 @@ func (m SelectionModel[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 
-			return m, tea.Batch(cmd, m.list.NewStatusMessage(Colorize(ColorGreen, fmt.Sprintf("Refreshed: %d items", len(items)))))
+			return m, tea.Batch(cmd, m.list.NewStatusMessage(Colorize(ColorGreen, fmt.Sprintf("Refreshed: %s", m.countSummary()))))
 		}
 		return m, nil
 

--- a/pkg/ui/selector_impl.go
+++ b/pkg/ui/selector_impl.go
@@ -148,11 +148,7 @@ func (m SelectionModel[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if items, ok := msg.items.([]T); ok {
 			m.items = items
-			listItems := make([]list.Item, len(items))
-			for i, item := range items {
-				listItems[i] = listItem[T]{value: item, item: m.opts.Renderer}
-			}
-			cmd := m.list.SetItems(listItems)
+			cmd := m.updateVisibleItems()
 
 			// If in detail view, refresh the viewport content
 			if m.showDetail {
@@ -471,11 +467,11 @@ func (m SelectionModel[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Toggle filter (h = hide/show resolved, tab kept for compatibility)
 			if m.opts.FilterFunc != nil {
 				m.filterActive = !m.filterActive
-				m.updateVisibleItems()
+				cmd := m.updateVisibleItems()
 				if m.filterActive {
-					return m, m.list.NewStatusMessage("Hiding resolved")
+					return m, tea.Batch(cmd, m.list.NewStatusMessage("Hiding resolved"))
 				}
-				return m, m.list.NewStatusMessage("Showing all")
+				return m, tea.Batch(cmd, m.list.NewStatusMessage("Showing all"))
 			}
 			return m, nil
 		case "i":
@@ -730,15 +726,16 @@ func (m *SelectionModel[T]) launchAgent(prompt string) tea.Cmd {
 	})
 }
 
-// updateVisibleItems applies filter and updates the list
-func (m *SelectionModel[T]) updateVisibleItems() {
+// updateVisibleItems applies filter and updates the list. It returns the
+// command SetItems produces, which re-runs any active text filter.
+func (m *SelectionModel[T]) updateVisibleItems() tea.Cmd {
 	listItems := make([]list.Item, 0, len(m.items))
 	for _, item := range m.items {
 		if m.opts.FilterFunc == nil || m.opts.FilterFunc(item, m.filterActive) {
 			listItems = append(listItems, listItem[T]{value: item, item: m.opts.Renderer})
 		}
 	}
-	m.list.SetItems(listItems)
+	return m.list.SetItems(listItems)
 }
 
 // countSummary renders the item tally shown above the list.

--- a/pkg/ui/selector_test.go
+++ b/pkg/ui/selector_test.go
@@ -1,12 +1,14 @@
 package ui
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 )
 
 func TestSanitizeEditorContent(t *testing.T) {
@@ -1457,5 +1459,64 @@ func TestListViewShowsCountableTallyNotRowCount(t *testing.T) {
 	}
 	if strings.Contains(view, "3 items") {
 		t.Errorf("View() still reports the raw row count %q\n%s", "3 items", view)
+	}
+}
+
+// plainRenderer renders no description, so a rendered row is just its title.
+type plainRenderer struct{ mockRenderer }
+
+func (r plainRenderer) Description(item string) string { return "" }
+
+func TestItemDelegateTruncatesOnVisibleWidthNotBytes(t *testing.T) {
+	// A colorized row wider than the list must truncate on visible columns
+	// rather than bytes, and must keep its reset so color does not bleed
+	// into the rest of the line.
+	long := Colorize(ColorGray, strings.Repeat("a", 100))
+	items := []string{"first", long}
+
+	renderer := plainRenderer{}
+	opts := SelectorOptions[string]{Items: items, Renderer: renderer}
+	m := newTestModel(items, opts)
+
+	var buf bytes.Buffer
+	itemDelegate[string]{renderer: renderer}.Render(
+		&buf, m.list, 1, listItem[string]{value: long, item: renderer})
+	out := buf.String()
+
+	// The list is 80 wide; the delegate allows 4 columns and prepends a
+	// two-space gutter, so a truncated row occupies 76 + 2 columns.
+	if got, want := ansi.StringWidth(out), 78; got != want {
+		t.Errorf("rendered visible width = %d, want %d\n%q", got, want, out)
+	}
+	if !strings.Contains(out, ColorReset) {
+		t.Errorf("rendered row lost its color reset: %q", out)
+	}
+}
+
+func TestItemDelegateKeepsHyperlinkIntactWhenTruncating(t *testing.T) {
+	// A hyperlinked row carries roughly 100 bytes of invisible OSC8 payload,
+	// so a byte-based cut lands inside the URL and leaves the terminal in an
+	// unterminated escape sequence.
+	url := "https://github.com/owner/repo/pull/10661#discussion_r3865507885"
+	linked := CreateHyperlink(url, Colorize(ColorGray, strings.Repeat("a", 90)))
+	items := []string{"first", linked}
+
+	renderer := plainRenderer{}
+	opts := SelectorOptions[string]{Items: items, Renderer: renderer}
+	m := newTestModel(items, opts)
+
+	var buf bytes.Buffer
+	itemDelegate[string]{renderer: renderer}.Render(
+		&buf, m.list, 1, listItem[string]{value: linked, item: renderer})
+	out := buf.String()
+
+	if !strings.Contains(out, "\x1b]8;;"+url+"\x1b\\") {
+		t.Errorf("truncation broke the OSC8 open sequence: %q", out)
+	}
+	if !strings.HasSuffix(out, "\x1b]8;;\x1b\\") {
+		t.Errorf("truncation dropped the OSC8 close sequence: %q", out)
+	}
+	if got, want := ansi.StringWidth(out), 78; got != want {
+		t.Errorf("rendered visible width = %d, want %d", got, want)
 	}
 }

--- a/pkg/ui/selector_test.go
+++ b/pkg/ui/selector_test.go
@@ -1520,3 +1520,46 @@ func TestItemDelegateKeepsHyperlinkIntactWhenTruncating(t *testing.T) {
 		t.Errorf("rendered visible width = %d, want %d", got, want)
 	}
 }
+
+// visibleValues returns the values the list is currently showing.
+func visibleValues(m SelectionModel[string]) []string {
+	var out []string
+	for _, listed := range m.list.Items() {
+		out = append(out, listed.(listItem[string]).value)
+	}
+	return out
+}
+
+func TestRefreshKeepsHideResolvedFilterApplied(t *testing.T) {
+	hideResolved := func(item string, active bool) bool {
+		if !active {
+			return true
+		}
+		return !strings.HasPrefix(item, "resolved:")
+	}
+
+	items := []string{"open:1", "resolved:1"}
+	m := newTestModel(items, SelectorOptions[string]{
+		Items:         items,
+		Renderer:      mockRenderer{previewContent: "preview"},
+		FilterFunc:    hideResolved,
+		FilterDefault: true,
+		RefreshItems:  func() ([]string, error) { return nil, nil },
+	})
+	m.updateVisibleItems()
+
+	fresh := []string{"open:1", "open:2", "resolved:1", "resolved:2"}
+	updated, _ := m.Update(refreshFinishedMsg{items: fresh})
+	result := updated.(SelectionModel[string])
+
+	if got, want := strings.Join(visibleValues(result), ","), "open:1,open:2"; got != want {
+		t.Errorf("visible after refresh = %q, want %q", got, want)
+	}
+	if !result.filterActive {
+		t.Error("refresh should leave the hide-resolved filter active")
+	}
+	if got, want := len(result.items), 4; got != want {
+		t.Errorf("backing items = %d, want %d (refresh must keep every item)", got, want)
+	}
+}
+

--- a/pkg/ui/selector_test.go
+++ b/pkg/ui/selector_test.go
@@ -1563,3 +1563,36 @@ func TestRefreshKeepsHideResolvedFilterApplied(t *testing.T) {
 	}
 }
 
+
+func TestRefreshStatusReportsCountableTally(t *testing.T) {
+	hideResolved := func(item string, active bool) bool {
+		if !active {
+			return true
+		}
+		return !strings.HasPrefix(item, "resolved:")
+	}
+
+	items := []string{"header:a", "open:1", "resolved:1"}
+	m := newTestModel(items, SelectorOptions[string]{
+		Items:         items,
+		Renderer:      plainRenderer{},
+		FilterFunc:    hideResolved,
+		FilterDefault: true,
+		CountableItem: func(item string) bool { return !strings.HasPrefix(item, "header:") },
+		RefreshItems:  func() ([]string, error) { return nil, nil },
+	})
+	m.updateVisibleItems()
+
+	// Five rows, of which two are countable and visible once resolved rows
+	// are hidden.
+	fresh := []string{"header:a", "open:1", "open:2", "resolved:1", "resolved:2"}
+	updated, _ := m.Update(refreshFinishedMsg{items: fresh})
+	view := updated.(SelectionModel[string]).View()
+
+	if !strings.Contains(view, "Refreshed: 2 items") {
+		t.Errorf("status should report the countable visible tally\n%s", view)
+	}
+	if strings.Contains(view, "Refreshed: 5 items") {
+		t.Errorf("status still reports the raw row count\n%s", view)
+	}
+}


### PR DESCRIPTION
### fix: truncate list rows on visible columns, not bytes

**Problem:** Colorized rows in the Browse view are cut several columns short of the space actually available, and the cut discards the trailing reset code, so the color of one row bleeds into the rest of the line.

**Cause:** `itemDelegate.Render()` in `selector_impl.go` measures a row with `len()` and shortens it with a byte slice. ANSI escapes occupy bytes but no columns, so they're counted against the row width. And slices can land inside an escape sequence, rather than between two visible characters.

**Fix:** Title and description are both shortened with `ansi.Truncate()`, which measures visible columns and steps over escape sequences instead of through them. This promotes `github.com/charmbracelet/x/ansi` from an indirect dependency to a direct one; it is already in the module graph by way of `bubbles`, so nothing new is downloaded. The accompanying test renders a row carrying an OSC8 hyperlink, whose invisible payload is large enough that a byte slice lands inside the URL and leaves the terminal in an unterminated escape sequence.

### feat: link Browse comment excerpts to their GitHub comments

**Problem:** A review comment excerpt in the Browse view offers no way to reach the comment on GitHub by clicking it. A comment body written in a non-Latin script also renders as mojibake once the excerpt grows long enough to be shortened.

**Cause:** The excerpt branch of `browseItemRenderer.Title()` in `cmd/browse.go` emits plain colorized text and never uses the comment URL, which is already cached on the comment from the initial fetch. It also caps the excerpt with `len()` and a byte slice, so a cap that falls inside a multi-byte rune splits that rune in half.

**Fix:** The excerpt is wrapped in an OSC8 hyperlink to the comment URL — with the leading indent left outside the link, so only the text itself is clickable. Terminals without OSC8 support swallow the sequence, and `CreateHyperlink()` returns its text unchanged when color is disabled or the comment carries no URL. So both cases fall back to the plain excerpt. The cap now measures visible columns with `ansi.StringWidth()` and shortens with `ansi.Truncate()`, which never splits a rune.

### fix: keep the hide-resolved filter applied when refreshing

**Problem:** With resolved comments hidden, pressing `i` to refresh the Browse view brings all the resolved comments back. Getting back to the unresolved-only view then takes two presses of `h`, because the first press only clears a flag the display is already ignoring.

**Cause:** Two paths populate the list. `updateVisibleItems()` in `selector_impl.go` builds it through the configured filter, while the refresh handler builds it inline from every fetched item and never consults that filter. The flag itself is left alone, so after a refresh the model still holds that resolved comments are hidden while the list is showing them.

**Fix:** The refresh handler rebuilds the list through `updateVisibleItems()`, leaving one path that knows how the list gets populated. That method now returns the command `SetItems()` produces, which re-runs an active text filter, so refreshing in the middle of a search keeps the search applied. The `h` toggle passes the same command along for the same reason.

### fix: match the refresh message to the tally above the list

**Problem:** Refreshing the Browse view reports a different total from the line directly above it. On one pull request the refresh message reads 41 items while the tally reads 9 items, so the two contradict each other on screen at the same moment.

**Cause:** The refresh handler in `selector_impl.go` counts the whole item slice, which carries a row for every file heading and every comment preview alongside the comments themselves. The tally comes from `countSummary()`, which counts only the entries a caller marks countable.

**Fix:** The refresh message is built from `countSummary()` as well, so one counter produces both lines and they cannot drift apart.
