### PR TITLE
feat: summarize CodeRabbit comments by severity and title

### DIFF
--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -20,6 +20,19 @@ import (
 var (
 	markdownImageRe = regexp.MustCompile(`!\[.*?\]\(.*?\)`)
 	markdownLinkRe  = regexp.MustCompile(`\[([^\]]*)\]\([^)]*\)`)
+
+	// coderabbitSeverityRe matches the header line CodeRabbit puts at the top
+	// of a review comment: three underscore-delimited segments separated by
+	// pipes, the second of which carries the severity.
+	coderabbitSeverityRe = regexp.MustCompile(`^_[^_]+_\s*\|\s*_([^_]+)_\s*\|`)
+
+	// coderabbitTitleRe matches a bold span at the start of a line. Anchoring
+	// to the line start keeps it clear of the bold markers that turn up inside
+	// the shell snippets CodeRabbit embeds in its collapsed analysis blocks.
+	coderabbitTitleRe = regexp.MustCompile(`^\s*\*\*(.+?)\*\*`)
+
+	// severityLeadInRe matches the emoji and spacing ahead of a severity word.
+	severityLeadInRe = regexp.MustCompile(`^[^\p{L}\p{N}]+`)
 )
 
 var browseDebug bool
@@ -523,6 +536,60 @@ type BrowseItem struct {
 	HasUnresolved      bool // for "file" headers: whether the file has any unresolved comment
 }
 
+// coderabbitSummary extracts the severity and the title from a CodeRabbit
+// review comment body, reporting false for a body that is not one.
+func coderabbitSummary(body string) (severity, title string, ok bool) {
+	lines := strings.Split(body, "\n")
+	header := coderabbitSeverityRe.FindStringSubmatch(lines[0])
+	if header == nil {
+		return "", "", false
+	}
+
+	// CodeRabbit security findings open with taxonomy labels such as
+	// "Sensitive Data Exposure (CWE-200):" and "Reachability:" ahead of the
+	// sentence that names the finding. Prefer that sentence, and settle for
+	// the first label only when nothing else follows it.
+	var label string
+	for _, line := range lines[1:] {
+		match := coderabbitTitleRe.FindStringSubmatch(line)
+		if match == nil {
+			continue
+		}
+		candidate := strings.TrimSpace(match[1])
+		if !strings.HasSuffix(candidate, ":") {
+			return strings.TrimSpace(header[1]), candidate, true
+		}
+		if label == "" {
+			label = candidate
+		}
+	}
+	if label != "" {
+		return strings.TrimSpace(header[1]), label, true
+	}
+	return "", "", false
+}
+
+// coderabbitExcerpt renders the tree summary for a CodeRabbit review comment,
+// returning an empty string for a body that is not one.
+func coderabbitExcerpt(body string) string {
+	severity, title, ok := coderabbitSummary(body)
+	if !ok {
+		return ""
+	}
+	return ui.EmojiText(severity, severityLeadInRe.ReplaceAllString(severity, "")) + ": " + title
+}
+
+// firstLineExcerpt returns the first line of a comment body, marked with an
+// ellipsis when the body carries more lines.
+func firstLineExcerpt(body string) string {
+	lines := strings.Split(ui.StripSuggestionBlock(body), "\n")
+	preview := lines[0]
+	if len(lines) > 1 {
+		preview += "..."
+	}
+	return preview
+}
+
 // browseFilter reports whether item should be visible, given whether resolved
 // comments are hidden and which files are collapsed.
 func browseFilter(item BrowseItem, hideResolved bool, collapsedFiles map[string]bool) bool {
@@ -668,18 +735,14 @@ func (r *browseItemRenderer) Title(item BrowseItem) string {
 		// Show truncated body for preview item in gray
 		// Note: This works because IsSkippable returns false, so lipgloss
 		// won't re-style this text and interfere with the ANSI codes
-		body := ui.StripSuggestionBlock(item.Comment.Body)
-		lines := strings.Split(body, "\n")
-		preview := "..."
-		if len(lines) > 0 {
-			preview = lines[0]
-			// Truncate on visible columns so that a multi-byte rune is
-			// never sliced in half.
-			if ansi.StringWidth(preview) > 80 {
-				preview = ansi.Truncate(preview, 80, "...")
-			} else if len(lines) > 1 {
-				preview += "..."
-			}
+		preview := coderabbitExcerpt(item.Comment.Body)
+		if preview == "" {
+			preview = firstLineExcerpt(item.Comment.Body)
+		}
+		// Truncate on visible columns so that a multi-byte rune is never
+		// sliced in half.
+		if ansi.StringWidth(preview) > 80 {
+			preview = ansi.Truncate(preview, 80, "...")
 		}
 		// The indent stays outside the link so that only the excerpt itself
 		// is clickable.

--- a/cmd/browse_test.go
+++ b/cmd/browse_test.go
@@ -681,3 +681,149 @@ func TestBrowseItemRenderer_PreviewExcerptTruncatesOnRuneBoundary(t *testing.T) 
 		t.Errorf("excerpt truncation split a rune: %q", plain)
 	}
 }
+
+// Fixtures mirror real CodeRabbit review comment bodies.
+func crBody(lines ...string) string { return strings.Join(lines, "\n") }
+
+func TestCoderabbitSummary(t *testing.T) {
+	tests := []struct {
+		name         string
+		body         string
+		wantSeverity string
+		wantTitle    string
+		wantOK       bool
+	}{
+		{
+			name: "title on the third line",
+			body: crBody(
+				"_\U0001FA7A Stability & Availability_ | _\U0001F7E0 Major_ | _\u26A1 Quick win_",
+				"",
+				"**Grant Accessibility to the Python executable.**",
+				"",
+				"The macOS branch calls setFocus after every tree update."),
+			wantSeverity: "\U0001F7E0 Major",
+			wantTitle:    "Grant Accessibility to the Python executable.",
+			wantOK:       true,
+		},
+		{
+			name: "title follows a collapsed analysis block",
+			body: crBody(
+				"_\U0001F3AF Functional Correctness_ | _\U0001F7E0 Major_ | _\u26A1 Quick win_",
+				"",
+				"<details>",
+				"<summary>\U0001F9E9 Analysis chain</summary>",
+				"",
+				"```shell",
+				"rg -n -P -C4 '**/*.h Libraries/LibWeb/'",
+				"```",
+				"",
+				"</details>",
+				"",
+				"**Track traversal depth instead of limiting child count.**"),
+			wantSeverity: "\U0001F7E0 Major",
+			wantTitle:    "Track traversal depth instead of limiting child count.",
+			wantOK:       true,
+		},
+		{
+			name: "title carries trailing prose on the same line",
+			body: crBody(
+				"_\U0001FA7A Stability & Availability_ | _\U0001F7E1 Minor_ | _\u26A1 Quick win_",
+				"",
+				"**Deregistered interfaces leak their QObjects.** Each interface allocates one."),
+			wantSeverity: "\U0001F7E1 Minor",
+			wantTitle:    "Deregistered interfaces leak their QObjects.",
+			wantOK:       true,
+		},
+		{
+			name: "label-style bold headings are skipped for the real title",
+			body: crBody(
+				"_\U0001F512 Security & Privacy_ | _\U0001F7E0 Major_ | _\u26A1 Quick win_",
+				"",
+				"**Sensitive Data Exposure (CWE-200):** Exposure of Sensitive Information",
+				"",
+				"**Reachability:** External",
+				"",
+				"**Mask password text in the accessibility tree**",
+				"",
+				"The tree already skips type=password for node_data.value."),
+			wantSeverity: "\U0001F7E0 Major",
+			wantTitle:    "Mask password text in the accessibility tree",
+			wantOK:       true,
+		},
+		{
+			name: "falls back to the label when every bold span is one",
+			body: crBody(
+				"_\U0001F512 Security & Privacy_ | _\U0001F7E0 Major_ | _\u26A1 Quick win_",
+				"",
+				"**Other (CWE-377):** Insecure Temporary File",
+				"",
+				"**Reachability:** External"),
+			wantSeverity: "\U0001F7E0 Major",
+			wantTitle:    "Other (CWE-377):",
+			wantOK:       true,
+		},
+		{
+			name:   "coderabbit reply carries no severity line",
+			body:   "`@sideshowbarker`, acknowledged " + "\u2014" + " this is cosmetic.",
+			wantOK: false,
+		},
+		{
+			name:   "ordinary human comment",
+			body:   crBody("This shouldn't be necessary since there's a global find_package now.", "", "Please drop it."),
+			wantOK: false,
+		},
+		{
+			name: "severity line with no bold title anywhere",
+			body: crBody(
+				"_\U0001F3AF Functional Correctness_ | _\U0001F7E0 Major_ | _\u26A1 Quick win_",
+				"",
+				"<details>",
+				"</details>"),
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			severity, title, ok := coderabbitSummary(tt.body)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if severity != tt.wantSeverity {
+				t.Errorf("severity = %q, want %q", severity, tt.wantSeverity)
+			}
+			if title != tt.wantTitle {
+				t.Errorf("title = %q, want %q", title, tt.wantTitle)
+			}
+		})
+	}
+}
+
+func TestCoderabbitExcerptDropsEmojiWithoutColor(t *testing.T) {
+	body := crBody(
+		"_\U0001FA7A Stability & Availability_ | _\U0001F7E0 Major_ | _\u26A1 Quick win_",
+		"",
+		"**Grant Accessibility to the Python executable.**")
+
+	restore := ui.ColorsEnabled()
+	defer ui.SetColorEnabled(restore)
+
+	ui.SetColorEnabled(true)
+	if got, want := coderabbitExcerpt(body), "\U0001F7E0 Major: Grant Accessibility to the Python executable."; got != want {
+		t.Errorf("with color: got %q, want %q", got, want)
+	}
+
+	ui.SetColorEnabled(false)
+	if got, want := coderabbitExcerpt(body), "Major: Grant Accessibility to the Python executable."; got != want {
+		t.Errorf("without color: got %q, want %q", got, want)
+	}
+}
+
+func TestCoderabbitExcerptIgnoresOtherComments(t *testing.T) {
+	if got := coderabbitExcerpt("Just a normal review comment."); got != "" {
+		t.Errorf("non-CodeRabbit body should yield no excerpt, got %q", got)
+	}
+}


### PR DESCRIPTION
**Problem:** Every CodeRabbit review comment opens with the same three-segment header line. So, the Browse view shows a column of identical summaries — and none of them says what the comment is actually about.

**Cause:** The excerpt branch of `browseItemRenderer.Title()` in `cmd/browse.go` takes the first line of the comment body verbatim. For a CodeRabbit comment, that line is the category, severity and effort header, which is repeated across every comment it posts. The sentence identifying the finding sits further down — as the first bold span in the body.

**Fix:** A CodeRabbit body is recognized by that header line rather than by its author, so a renamed or self-hosted bot keeps working. We grab the Major/Minor severity part from the header, and the title from the first line beginning with a bold span. Anchoring to the line start matters: CodeRabbit embeds shell snippets inside collapsed analysis blocks, and searching for a bold span anywhere pulls text out of those instead.

We give comments for security findings additional special handling. They start with prefixes such as “Sensitive Data Exposure (CWE-200):” and “Reachability:” ending in colons. So, to deal with those, we grab text from a bold span ending in a colon only when no other span follows it — and pass over it otherwise. That gives those security comments the same kind of actionable title as the rest.
